### PR TITLE
Run request_send handlers before sending request.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 Revision history for Perl module Test::WWW::Mechanize::PSGI:
 
+    - run request_send handlers before sending request (Olaf Alders)
+
 0.34 Sun Jan  3 12:02:29 GMT 2010
     - update the README to reflect the name
     - fix handling of cookies, patch by tokuhirom

--- a/lib/Test/WWW/Mechanize/PSGI.pm
+++ b/lib/Test/WWW/Mechanize/PSGI.pm
@@ -29,6 +29,8 @@ sub new {
 sub simple_request {
     my ( $self, $request ) = @_;
 
+    $self->run_handlers("request_send", $request);
+
     my $uri = $request->uri;
     $uri->scheme('http')    unless defined $uri->scheme;
     $uri->host('localhost') unless defined $uri->host;


### PR DESCRIPTION
Test::WWW::Mechanize::PSGI overrides LWP::UserAgent::simple_request(),
which is what would normally call LWP::UserAgent::send_request().
send_request() is what calls the request_send handlers.  So this module
effectively silently ignores any handlers which someone may want to add
to a UserAgent.

This patch fixes this by calling run_handlers() inside of the overridden
simple_request() method.  As it stands, this patch will silently ignore
any response object which may be created by a request_send handler.
