### PR TITLE
Make the submit_form_ok example runnable

### DIFF
--- a/lib/Test/WWW/Mechanize/PSGI.pm
+++ b/lib/Test/WWW/Mechanize/PSGI.pm
@@ -173,7 +173,7 @@ I<%parms> is a hashref containing the parms to pass to C<submit_form()>.
 Note that the parms to C<submit_form()> are a hash whereas the parms to
 this function are a hashref.  You have to call this function like:
 
-    $agent->submit_form_ok(
+    $agent->submit_form_ok({
         form_number => 3,
         fields      => {
             username    => 'mungo',


### PR DESCRIPTION
It expects the first argument to be a hashref, and was missing a `{`